### PR TITLE
refactor(README): update package names and remove outdated sections

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,33 +1,8 @@
-# `Turborepo` Vite starter
-
-This is a community-maintained example. If you experience a problem, please submit a pull request with a fix. GitHub Issues will be closed.
-
-## Using this example
-
-Run the following command:
-
-```sh
-npx create-turbo@latest -e with-vite
-```
-
-## What's inside?
-
-This Turborepo includes the following packages and apps:
+# t2421-web packages
 
 ### Apps and Packages
 
 - `docs`: a vanilla [vite](https://vitejs.dev) ts app
 - `web`: another vanilla [vite](https://vitejs.dev) ts app
-- `@repo/ui`: a stub component & utility library shared by both `web` and `docs` applications
-- `@repo/eslint-config`: shared `eslint` configurations
-- `@repo/typescript-config`: `tsconfig.json`s used throughout the monorepo
-
-Each package and app is 100% [TypeScript](https://www.typescriptlang.org/).
-
-### Utilities
-
-This Turborepo has some additional tools already setup for you:
-
-- [TypeScript](https://www.typescriptlang.org/) for static type checking
-- [ESLint](https://eslint.org/) for code linting
-- [Prettier](https://prettier.io) for code formatting
+- `@t2421/ui`: a stub component & utility library shared by both `web` and `docs` applications
+- `@t2421/typescript-config`: `tsconfig.json`s used throughout the monorepo


### PR DESCRIPTION
This pull request includes changes to the `README.md` file to update the project name and package references. The most important changes are:

Updates to project name and package references:

* Changed the project name from `Turborepo Vite starter` to `t2421-web packages`.
* Updated package references from `@repo` to `@t2421` to reflect the new project structure.